### PR TITLE
Neue Font Awesome Version 6 mit GraphQL API

### DIFF
--- a/FieldtypeRockAwesome.module.php
+++ b/FieldtypeRockAwesome.module.php
@@ -14,7 +14,7 @@ class FieldtypeRockAwesome extends FieldtypeText {
       'version' => '0.0.2',
       'summary' => 'Field that stores a FontAwesome icon string',
       'icon' => 'star-o',
-      'installs' => ['InputfieldRockAwesome', 'RockAwesome'],
+      'installs' => ['InputfieldRockAwesome'],
     ];
   }
 

--- a/InputfieldRockAwesome.config.php
+++ b/InputfieldRockAwesome.config.php
@@ -1,12 +1,33 @@
 <?php namespace ProcessWire;
 class InputfieldRockAwesomeConfig extends ModuleConfig {
     public function __construct() {
+
+
+        $url = 'https://api.fontawesome.com/';
+        $query = ['query' => 'query { releases {version} }'];
+        $http = new WireHttp();
+        $response = $http->post($url, $query, ['use' => 'fopen', 'fallback' => 'socket']);
+        $versions = []; $version_note = '';
+        if($response !== false) {
+            $releases = json_decode($response)->data->releases;
+            foreach ($releases AS $r) {
+                $versions[$r->version] = $r->version;
+            }
+            // $versions = array_reverse($versions);
+        }
+        if ($response===false || !count($versions)) {
+            $versions[] = 'latest';
+            $version_note = '**Error:** The available versions could not be retrieved from the Font Awesome API.';
+        }
+
+
+
         $this->add([
             [
                 'type' => 'markup',
                 'label' => 'HowTo',
                 'icon' => 'question',
-                'value' => 'Go to <a href="https://fontawesome.com/download">https://fontawesome.com/download</a> and download your version of FA. Then copy the CSS and METADATA folder to your website and set the paths below.',
+                'value' => 'Go to <a href="https://fontawesome.com/download">https://fontawesome.com/download</a> and download your version of FA. Then copy the CSS folder to your website and set the path below.',
             ],[
                 'name' => 'stylesheet',
                 'label' => 'Path to Stylesheet',
@@ -14,27 +35,38 @@ class InputfieldRockAwesomeConfig extends ModuleConfig {
                 'notes' => 'Relative to site root (' . $this->config->paths->root . ')',
                 'required' => true,
                 'value' => 'site/templates/fontawesome/css/all.css',
+            // ],[
+            //     'name' => 'json',
+            //     'label' => 'Path to JSON',
+            //     'type' => 'text',
+            //     'notes' => 'Relative to site root (' . $this->config->paths->root . ')',
+            //     'required' => true,
+            //     'value' => 'site/templates/fontawesome/metadata/icons.json',
             ],[
-                'name' => 'json',
-                'label' => 'Path to JSON',
-                'type' => 'text',
-                'notes' => 'Relative to site root (' . $this->config->paths->root . ')',
+                'name' => 'fa_version',
+                'label' => 'Font Awesome version',
+                'type' => 'select',
+                'notes' => $version_note,
                 'required' => true,
-                'value' => 'site/templates/fontawesome/metadata/icons.json',
+                'options' => $versions,
+                'columnWidth' => 50,
             ],[
-                'name' => 'version',
-                'label' => 'Exakte Version der installierten FontAwesome-Dateien',
-                'type' => 'text',
-                'notes' => 'Zur Abfrage der verfügbaren Icons, z.B. 6.0.0-beta3',
+                'name' => 'fa_membership',
+                'label' => 'Font Awesome license type',
+                'type' => 'select',
                 'required' => true,
-                'value' => '6.0.0-beta3',
+                'value' => 'free',
+                'options' => [
+                    '1' => 'free',
+                    '2' => 'pro',
+                ],
+                'columnWidth' => 50,
             ],[
                 'name' => 'styles',
-                'label' => 'Verfügbare Styles',
+                'label' => 'Available Styles',
                 'type' => 'Fieldset',
-                // 'notes' => 'Verfügbar: '.$this->styles->fas,
+                'notes' => 'Only these styles are displayed in the results list for selection.',
                 // 'required' => true,
-                // 'value' => '6.0.0-beta3',
                 'children' => [
                     [
                         'type' => "checkbox",
@@ -79,7 +111,7 @@ class InputfieldRockAwesomeConfig extends ModuleConfig {
                 'label' => 'Link to Icon Cheatsheat',
                 'type' => 'URL',
                 'required' => false,
-                'value' => 'https://fontawesome.com/cheatsheet/pro',
+                'value' => 'https://fontawesome.com/icons',
             ],
         ]);
     }

--- a/InputfieldRockAwesome.config.php
+++ b/InputfieldRockAwesome.config.php
@@ -1,118 +1,118 @@
 <?php namespace ProcessWire;
 class InputfieldRockAwesomeConfig extends ModuleConfig {
-    public function __construct() {
+  public function __construct() {
 
 
-        $url = 'https://api.fontawesome.com/';
-        $query = ['query' => 'query { releases {version} }'];
-        $http = new WireHttp();
-        $response = $http->post($url, $query, ['use' => 'fopen', 'fallback' => 'socket']);
-        $versions = []; $version_note = '';
-        if($response !== false) {
-            $releases = json_decode($response)->data->releases;
-            foreach ($releases AS $r) {
-                $versions[$r->version] = $r->version;
-            }
-            // $versions = array_reverse($versions);
-        }
-        if ($response===false || !count($versions)) {
-            $versions[] = 'latest';
-            $version_note = '**Error:** The available versions could not be retrieved from the Font Awesome API.';
-        }
-
-
-
-        $this->add([
-            [
-                'type' => 'markup',
-                'label' => 'HowTo',
-                'icon' => 'question',
-                'value' => 'Go to <a href="https://fontawesome.com/download">https://fontawesome.com/download</a> and download your version of FA. Then copy the CSS folder to your website and set the path below.',
-            ],[
-                'name' => 'stylesheet',
-                'label' => 'Path to Stylesheet',
-                'type' => 'text',
-                'notes' => 'Relative to site root (' . $this->config->paths->root . ')',
-                'required' => true,
-                'value' => 'site/templates/fontawesome/css/all.css',
-            // ],[
-            //     'name' => 'json',
-            //     'label' => 'Path to JSON',
-            //     'type' => 'text',
-            //     'notes' => 'Relative to site root (' . $this->config->paths->root . ')',
-            //     'required' => true,
-            //     'value' => 'site/templates/fontawesome/metadata/icons.json',
-            ],[
-                'name' => 'fa_version',
-                'label' => 'Font Awesome version',
-                'type' => 'select',
-                'notes' => $version_note,
-                'required' => true,
-                'options' => $versions,
-                'columnWidth' => 50,
-            ],[
-                'name' => 'fa_membership',
-                'label' => 'Font Awesome license type',
-                'type' => 'select',
-                'required' => true,
-                'value' => 'free',
-                'options' => [
-                    '1' => 'free',
-                    '2' => 'pro',
-                ],
-                'columnWidth' => 50,
-            ],[
-                'name' => 'styles',
-                'label' => 'Available Styles',
-                'type' => 'Fieldset',
-                'notes' => 'Only these styles are displayed in the results list for selection.',
-                // 'required' => true,
-                'children' => [
-                    [
-                        'type' => "checkbox",
-                        'label' => "Solid",
-                        'name' => "fas",
-                        'columnWidth' => 16,
-                        'value' => true,
-                    ],
-                    [
-                        'type' => "checkbox",
-                        'label' => "Regular",
-                        'name' => "far",
-                        'columnWidth' => 16,
-                    ],
-                    [
-                        'type' => "checkbox",
-                        'label' => "Light",
-                        'name' => "fal",
-                        'columnWidth' => 16,
-                    ],
-                    [
-                        'type' => "checkbox",
-                        'label' => "Thin",
-                        'name' => "fat",
-                        'columnWidth' => 16,
-                    ],
-                    [
-                        'type' => "checkbox",
-                        'label' => "Duotone",
-                        'name' => "fad",
-                        'columnWidth' => 16,
-                    ],
-                    [
-                        'type' => "checkbox",
-                        'label' => "Brands",
-                        'name' => "fab",
-                        'columnWidth' => 20,
-                    ],
-                ],
-            ],[
-                'name' => 'link',
-                'label' => 'Link to Icon Cheatsheat',
-                'type' => 'URL',
-                'required' => false,
-                'value' => 'https://fontawesome.com/icons',
-            ],
-        ]);
+    $url = 'https://api.fontawesome.com/';
+    $query = ['query' => 'query { releases {version} }'];
+    $http = new WireHttp();
+    $response = $http->post($url, $query, ['use' => 'fopen', 'fallback' => 'socket']);
+    $versions = []; $version_note = '';
+    if($response !== false) {
+      $releases = json_decode($response)->data->releases;
+      foreach ($releases AS $r) {
+        $versions[$r->version] = $r->version;
+      }
+      // $versions = array_reverse($versions);
     }
+    if ($response===false || !count($versions)) {
+        $versions[] = 'latest';
+        $version_note = '**Error:** The available versions could not be retrieved from the Font Awesome API.';
+    }
+
+
+
+    $this->add([
+      [
+        'type' => 'markup',
+        'label' => 'HowTo',
+        'icon' => 'question',
+        'value' => 'Go to <a href="https://fontawesome.com/download">https://fontawesome.com/download</a> and download your version of FA. Then copy the CSS folder to your website and fill the path below.',
+      ],[
+        'name' => 'stylesheet',
+        'label' => 'Path to Stylesheet',
+        'type' => 'text',
+        'notes' => 'Relative to site root (' . $this->config->paths->root . ')',
+        'required' => true,
+        'value' => 'site/templates/fontawesome/css/all.css',
+      // ],[
+      //     'name' => 'json',
+      //     'label' => 'Path to JSON',
+      //     'type' => 'text',
+      //     'notes' => 'Relative to site root (' . $this->config->paths->root . ')',
+      //     'required' => true,
+      //     'value' => 'site/templates/fontawesome/metadata/icons.json',
+      ],[
+        'name' => 'fa_version',
+        'label' => 'Font Awesome version',
+        'type' => 'select',
+        'notes' => $version_note,
+        'required' => true,
+        'options' => $versions,
+        'columnWidth' => 50,
+      ],[
+        'name' => 'fa_membership',
+        'label' => 'Font Awesome license type',
+        'type' => 'select',
+        'required' => true,
+        'value' => 'free',
+        'options' => [
+          '1' => 'free',
+          '2' => 'pro',
+        ],
+        'columnWidth' => 50,
+      ],[
+        'name' => 'styles',
+        'label' => 'Available Styles',
+        'type' => 'Fieldset',
+        'notes' => 'Only these styles are displayed in the results list for selection.',
+        // 'required' => true,
+        'children' => [
+          [
+            'type' => "checkbox",
+            'label' => "Solid",
+            'name' => "fas",
+            'columnWidth' => 16,
+            'value' => true,
+          ],
+          [
+            'type' => "checkbox",
+            'label' => "Regular",
+            'name' => "far",
+            'columnWidth' => 16,
+          ],
+          [
+            'type' => "checkbox",
+            'label' => "Light",
+            'name' => "fal",
+            'columnWidth' => 16,
+          ],
+          [
+            'type' => "checkbox",
+            'label' => "Thin",
+            'name' => "fat",
+            'columnWidth' => 16,
+          ],
+          [
+            'type' => "checkbox",
+            'label' => "Duotone",
+            'name' => "fad",
+            'columnWidth' => 16,
+          ],
+          [
+            'type' => "checkbox",
+            'label' => "Brands",
+            'name' => "fab",
+            'columnWidth' => 20,
+          ],
+        ],
+      ],[
+        'name' => 'link',
+        'label' => 'Link to Icon Cheatsheat',
+        'type' => 'URL',
+        'required' => false,
+        'value' => 'https://fontawesome.com/icons',
+      ],
+    ]);
+  }
 }

--- a/InputfieldRockAwesome.config.php
+++ b/InputfieldRockAwesome.config.php
@@ -1,33 +1,86 @@
 <?php namespace ProcessWire;
 class InputfieldRockAwesomeConfig extends ModuleConfig {
-  public function __construct() {
-    $this->add([
-      [
-        'type' => 'markup',
-        'label' => 'HowTo',
-        'icon' => 'question',
-        'value' => 'Go to <a href="https://fontawesome.com/download">https://fontawesome.com/download</a> and download your version of FA. Then copy the CSS and METADATA folder to your website and set the paths below.',
-      ],[
-        'name' => 'stylesheet',
-        'label' => 'Path to Stylesheet',
-        'type' => 'text',
-        'notes' => 'Relative to site root (' . $this->config->paths->root . ')',
-        'required' => true,
-        'value' => 'site/templates/fontawesome/css/all.css',
-      ],[
-        'name' => 'json',
-        'label' => 'Path to JSON',
-        'type' => 'text',
-        'notes' => 'Relative to site root (' . $this->config->paths->root . ')',
-        'required' => true,
-        'value' => 'site/templates/fontawesome/metadata/icons.json',
-      ],[
-        'name' => 'link',
-        'label' => 'Link to Icon Cheatsheat',
-        'type' => 'URL',
-        'required' => false,
-        'value' => 'https://fontawesome.com/cheatsheet/pro',
-      ],
-    ]);
-  }
+    public function __construct() {
+        $this->add([
+            [
+                'type' => 'markup',
+                'label' => 'HowTo',
+                'icon' => 'question',
+                'value' => 'Go to <a href="https://fontawesome.com/download">https://fontawesome.com/download</a> and download your version of FA. Then copy the CSS and METADATA folder to your website and set the paths below.',
+            ],[
+                'name' => 'stylesheet',
+                'label' => 'Path to Stylesheet',
+                'type' => 'text',
+                'notes' => 'Relative to site root (' . $this->config->paths->root . ')',
+                'required' => true,
+                'value' => 'site/templates/fontawesome/css/all.css',
+            ],[
+                'name' => 'json',
+                'label' => 'Path to JSON',
+                'type' => 'text',
+                'notes' => 'Relative to site root (' . $this->config->paths->root . ')',
+                'required' => true,
+                'value' => 'site/templates/fontawesome/metadata/icons.json',
+            ],[
+                'name' => 'version',
+                'label' => 'Exakte Version der installierten FontAwesome-Dateien',
+                'type' => 'text',
+                'notes' => 'Zur Abfrage der verfügbaren Icons, z.B. 6.0.0-beta3',
+                'required' => true,
+                'value' => '6.0.0-beta3',
+            ],[
+                'name' => 'styles',
+                'label' => 'Verfügbare Styles',
+                'type' => 'Fieldset',
+                // 'notes' => 'Verfügbar: '.$this->styles->fas,
+                // 'required' => true,
+                // 'value' => '6.0.0-beta3',
+                'children' => [
+                    [
+                        'type' => "checkbox",
+                        'label' => "Solid",
+                        'name' => "fas",
+                        'columnWidth' => 16,
+                        'value' => true,
+                    ],
+                    [
+                        'type' => "checkbox",
+                        'label' => "Regular",
+                        'name' => "far",
+                        'columnWidth' => 16,
+                    ],
+                    [
+                        'type' => "checkbox",
+                        'label' => "Light",
+                        'name' => "fal",
+                        'columnWidth' => 16,
+                    ],
+                    [
+                        'type' => "checkbox",
+                        'label' => "Thin",
+                        'name' => "fat",
+                        'columnWidth' => 16,
+                    ],
+                    [
+                        'type' => "checkbox",
+                        'label' => "Duotone",
+                        'name' => "fad",
+                        'columnWidth' => 16,
+                    ],
+                    [
+                        'type' => "checkbox",
+                        'label' => "Brands",
+                        'name' => "fab",
+                        'columnWidth' => 20,
+                    ],
+                ],
+            ],[
+                'name' => 'link',
+                'label' => 'Link to Icon Cheatsheat',
+                'type' => 'URL',
+                'required' => false,
+                'value' => 'https://fontawesome.com/cheatsheet/pro',
+            ],
+        ]);
+    }
 }

--- a/InputfieldRockAwesome.js
+++ b/InputfieldRockAwesome.js
@@ -21,21 +21,32 @@
                 return;
             }
             html = "";
-            $.post( "https://api.fontawesome.com/", { query: 'query { search(version: "'+ProcessWire.config.RockAwesomeVersion+'", query: "'+str+'", first: 50) { id styles } }' }, function( data ) {
+            $.post( "https://api.fontawesome.com/", { query: 'query { search(version: "'+ProcessWire.config.RockAwesomeVersion+'", query: "'+str+'", first: 150) { id label membership {pro free} } }' }, function( data ) {
                 $.each(data.data.search, function(i, icon) {
-                    $.each(icon.styles, function(i,style) {
+                    console.log(ProcessWire.config.RockAwesomeMembership);
+                    console.log(ProcessWire.config.RockAwesomeDuotone);
+                    console.log(icon);
+                    if (ProcessWire.config.RockAwesomeMembership*1>1) {
+                        // Pro
+                        mystyles = icon.membership.pro;
+                    }
+                    else {
+                        mystyles = icon.membership.free;
+                    }
+
+                    $.each(mystyles, function(i,style) {
                         if (
-                            style == "solid" && ProcessWire.config.RockAwesomeSolid
-                            || style == "regular" && ProcessWire.config.RockAwesomeRegular
-                            || style == "light" && ProcessWire.config.RockAwesomeLight
-                            || style == "thin" && ProcessWire.config.RockAwesomeThin
-                            || style == "duotone" && ProcessWire.config.RockAwesomeDuotone
-                            || style == "brands" && ProcessWire.config.RockAwesomeBrands
+                                style == "solid" && ProcessWire.config.RockAwesomeSolid
+                                || style == "regular" && ProcessWire.config.RockAwesomeRegular
+                                || style == "light" && ProcessWire.config.RockAwesomeLight
+                                || style == "thin" && ProcessWire.config.RockAwesomeThin
+                                || style == "duotone" && ProcessWire.config.RockAwesomeDuotone
+                                || style == "brands" && ProcessWire.config.RockAwesomeBrands
                         ) {
-                            html += "<div class='icon' style='cursor: pointer; text-align: center;'>"
-                            +"<i class='fa" + style[0] + " fa-" + icon.id + " fa-2x' style='width: 35px; '></i>"
+                            html += "<div class='icon' style='cursor: pointer; text-align: center;' data-rock-icon='"+"fa" + style[0] + " fa-" +icon.id+"'>"
+                            +"<i class='fa" + style[0] + " fa-" + icon.id + " fa-2x' style='width: 35px;'></i>"
                             +'<br><small>'
-                            +"fa" + style[0] + " fa-" +icon.id
+                            +icon.label
                             +'</small>'
                             +"</div>";
                         }
@@ -50,7 +61,7 @@
     // handle clicks on icons
     $(document).on('click', '.RockAwesome .icon', function(e) {
         let $ra = $(e.target).closest('.RockAwesome');
-        var icon = $(e.target).closest('.icon').text();
+        var icon = $(e.target).closest('.icon').data('rock-icon');
         $icons = $ra.find('.icons');
         $input = $ra.find('input');
         $input.val(icon);

--- a/InputfieldRockAwesome.js
+++ b/InputfieldRockAwesome.js
@@ -1,71 +1,98 @@
 (function() {
-    var timers = {};
+   // var timers = {};
+   var debounce = function(func, wait, immediate) {
+      var wait = wait || 500; // 500ms default
+      var timeout;
+      return function() {
+        var context = this, args = arguments;
+        var later = function() {
+          timeout = null;
+          if (!immediate) func.apply(context, args);
+        };
+        var callNow = immediate && !timeout;
+        clearTimeout(timeout);
+        timeout = setTimeout(later, wait);
+        if (callNow) func.apply(context, args);
+      };
+    };
 
-    // show list of icons from fontawesome API
-    $(document).on('input change', '.RockAwesome input', function(e) {
-            let $ra = $(e.target).closest('.RockAwesome');
-            let $li = $ra.closest('.Inputfield');
-            let id = $li.attr('id');
 
-            clearTimeout(timers[id]);
-            timers[id] = setTimeout(function() {
+   // show list of icons from fontawesome API
+   $(document).on('input change', '.RockAwesome input', debounce(function(e) {
+      $ra = $(e.target).closest('.RockAwesome');
+      $input = $ra.find('input');
+      $icons = $ra.find('.icons');
+      var str = $input.val() + '';
 
-            let $input = $ra.find('input');
-            let $icons = $ra.find('.icons');
-            let str = $input.val()+'';
-            str = str.toLocaleLowerCase();
+      $li = $ra.closest('.Inputfield');
+      id = $li.attr('id');
 
-            if (str.match(/fa[srltdb] fa-.*/)) { // Wenn bereits ein gültiger FA-String übergeben wurde
-                $ra.find('.uk-form-icon i').attr('class', str);
-                $icons.html('');
-                return;
+      // clearTimeout(timers[id]);
+      // timers[id] = setTimeout(function() {
+
+      str = str.toLocaleLowerCase();
+
+      if (!str) { // if no string
+         $ra.find('.uk-form-icon i').attr('class', "");
+         return;
+      }
+      // show spinner
+      $ra.find('.uk-form-icon i').attr('class', 'fa fa-spinner fa-spin');
+
+      if (str.match(/fa[srltdb] fa-.*/)) { // if a valid FA string is submitted
+         $ra.find('.uk-form-icon i').attr('class', str);
+         $icons.html('');
+         return;
+      }
+      html = "";
+
+      $.post( "https://api.fontawesome.com/", { query: 'query { search(version: "'+ProcessWire.config.RockAwesomeVersion+'", query: "'+str+'", first: 150) { id label membership {pro free} } }' }, function( data ) {
+         $.each(data.data.search, function(i, icon) {
+            console.log(ProcessWire.config.RockAwesomeMembership);
+            console.log(ProcessWire.config.RockAwesomeDuotone);
+            console.log(icon);
+            if (ProcessWire.config.RockAwesomeMembership*1>1) {
+               // Pro
+               mystyles = icon.membership.pro;
             }
-            html = "";
-            $.post( "https://api.fontawesome.com/", { query: 'query { search(version: "'+ProcessWire.config.RockAwesomeVersion+'", query: "'+str+'", first: 150) { id label membership {pro free} } }' }, function( data ) {
-                $.each(data.data.search, function(i, icon) {
-                    console.log(ProcessWire.config.RockAwesomeMembership);
-                    console.log(ProcessWire.config.RockAwesomeDuotone);
-                    console.log(icon);
-                    if (ProcessWire.config.RockAwesomeMembership*1>1) {
-                        // Pro
-                        mystyles = icon.membership.pro;
-                    }
-                    else {
-                        mystyles = icon.membership.free;
-                    }
+            else {
+               mystyles = icon.membership.free;
+            }
 
-                    $.each(mystyles, function(i,style) {
-                        if (
-                                style == "solid" && ProcessWire.config.RockAwesomeSolid
-                                || style == "regular" && ProcessWire.config.RockAwesomeRegular
-                                || style == "light" && ProcessWire.config.RockAwesomeLight
-                                || style == "thin" && ProcessWire.config.RockAwesomeThin
-                                || style == "duotone" && ProcessWire.config.RockAwesomeDuotone
-                                || style == "brands" && ProcessWire.config.RockAwesomeBrands
-                        ) {
-                            html += "<div class='icon' style='cursor: pointer; text-align: center;' data-rock-icon='"+"fa" + style[0] + " fa-" +icon.id+"'>"
-                            +"<i class='fa" + style[0] + " fa-" + icon.id + " fa-2x' style='width: 35px;'></i>"
-                            +'<br><small>'
-                            +icon.label
-                            +'</small>'
-                            +"</div>";
-                        }
-                    });
-                })
-                $icons.html(html);
-            }, "json");
+            $.each(mystyles, function(i,style) {
+               if (
+                  style == "solid" && ProcessWire.config.RockAwesomeSolid
+                  || style == "regular" && ProcessWire.config.RockAwesomeRegular
+                  || style == "light" && ProcessWire.config.RockAwesomeLight
+                  || style == "thin" && ProcessWire.config.RockAwesomeThin
+                  || style == "duotone" && ProcessWire.config.RockAwesomeDuotone
+                  || style == "brands" && ProcessWire.config.RockAwesomeBrands
+               ) {
+                  html += "<div class='icon' style='cursor: pointer; text-align: center;' data-rock-icon='"+"fa" + style[0] + " fa-" +icon.id+"'>"
+                  +"<i class='fa" + style[0] + " fa-" + icon.id + " fa-2x' style='width: 35px;'></i>"
+                  +'<br><small>'
+                  +icon.label
+                  +'</small>'
+                  +"</div>";
+               }
+            });
+         })
+         $icons.html(html);
+         $ra.find('.uk-form-icon i').attr('class', "");
 
-        }, 300);
-    });
+      }, "json");
 
-    // handle clicks on icons
-    $(document).on('click', '.RockAwesome .icon', function(e) {
-        let $ra = $(e.target).closest('.RockAwesome');
-        var icon = $(e.target).closest('.icon').data('rock-icon');
-        $icons = $ra.find('.icons');
-        $input = $ra.find('input');
-        $input.val(icon);
-        $ra.find('.uk-form-icon i').attr('class', icon);
-        $icons.html('');
-    });
+      // }, 300);
+   }));
+
+   // handle clicks on icons
+   $(document).on('click', '.RockAwesome .icon', function(e) {
+      let $ra = $(e.target).closest('.RockAwesome');
+      var icon = $(e.target).closest('.icon').data('rock-icon');
+      $icons = $ra.find('.icons');
+      $input = $ra.find('input');
+      $input.val(icon);
+      $ra.find('.uk-form-icon i').attr('class', icon);
+      $icons.html('');
+   });
 }());

--- a/InputfieldRockAwesome.module.php
+++ b/InputfieldRockAwesome.module.php
@@ -28,8 +28,9 @@ class InputfieldRockAwesome extends InputfieldText {
     $style = str_replace($this->config->paths->root, $this->config->urls->root, $this->stylesheet);
     $this->config->styles->add($style);
 
-    // Gewünschte Icon-Styles in JS bekannt machen
-    $this->config->js('RockAwesomeVersion', $this->version);
+    // Versionsinfos und gewünschte Icon-Styles in JS bekannt machen
+    $this->config->js('RockAwesomeVersion', $this->fa_version);
+    $this->config->js('RockAwesomeMembership', $this->fa_membership);
     $this->config->js('RockAwesomeRegular', $this->far);
     $this->config->js('RockAwesomeSolid', $this->fas);
     $this->config->js('RockAwesomeLight', $this->fal);
@@ -48,6 +49,8 @@ class InputfieldRockAwesome extends InputfieldText {
 
       $event->object->notes .= $notes;
     });
+
+
   }
 
   /**

--- a/InputfieldRockAwesome.module.php
+++ b/InputfieldRockAwesome.module.php
@@ -28,7 +28,14 @@ class InputfieldRockAwesome extends InputfieldText {
     $style = str_replace($this->config->paths->root, $this->config->urls->root, $this->stylesheet);
     $this->config->styles->add($style);
 
-    $this->setIcons();
+    // Gewünschte Icon-Styles in JS bekannt machen
+    $this->config->js('RockAwesomeVersion', $this->version);
+    $this->config->js('RockAwesomeRegular', $this->far);
+    $this->config->js('RockAwesomeSolid', $this->fas);
+    $this->config->js('RockAwesomeLight', $this->fal);
+    $this->config->js('RockAwesomeThin', $this->fat);
+    $this->config->js('RockAwesomeDuotone', $this->fad);
+    $this->config->js('RockAwesomeBrands', $this->fab);
 
     $this->addHookBefore("render", function($event) {
       $n = $event->object->notes ? "\n" : "";
@@ -57,29 +64,10 @@ class InputfieldRockAwesome extends InputfieldText {
         ."<span class='uk-form-icon'><i></i></span>"
         ."<input $attrStr />"
       ."</div>"
-      ."<div class='icons uk-margin-small-top uk-child-width-1-1 uk-child-width-1-2@s uk-child-width-1-3@m uk-child-width-1-4@l' uk-grid></div>"
+      ."<div class='icons uk-margin-small-top uk-child-width-1-2 uk-child-width-1-3@s uk-child-width-1-4@m uk-child-width-1-6@l uk-grid-small' uk-grid></div>"
     ."</div>"
     ."<script>$('.ra_$id input').change();</script>";
     return $out;
   }
 
-  /**
-   * Set JS array of all icons
-   * @return void
-   */
-  public function ___setIcons() {
-    $this->json = $this->config->paths->root . $this->json;
-    if(!is_file($this->json)) throw new WireException("Json file not found");
-    $json = json_decode(file_get_contents($this->json));
-
-    // $out = "<div class='RockAwesomeIcons uk-margin uk-child-width-1-2 uk-child-width-1-3@m uk-child-width-1-4@l' uk-grid>";
-    $icons = [];
-    foreach ($json as $icon => $value) {
-      foreach ($value->styles as $style) {
-        $icons[] = "fa{$style[0]} fa-$icon";
-      }
-    }
-
-    $this->config->js('RockAwesome', $icons);
-  }
 }

--- a/InputfieldRockAwesome.module.php
+++ b/InputfieldRockAwesome.module.php
@@ -12,7 +12,7 @@ class InputfieldRockAwesome extends InputfieldText {
     return [
       'title' => 'RockAwesome', // Module Title
       'summary' => 'FontAwesome Icon Chooser', // Module Summary
-      'version' => '0.0.5',
+      'version' => '0.0.6',
       'icon' => 'star-o',
       'requires' => ['FieldtypeRockAwesome'],
     ];
@@ -65,6 +65,9 @@ class InputfieldRockAwesome extends InputfieldText {
     $out = "<div class='RockAwesome ra_$id'>"
       ."<div class='uk-inline uk-width-1-1'>"
         ."<span class='uk-form-icon'><i></i></span>"
+        // ."<span class='uk-form-icon uk-spinner'><i class='fa fa-spinner'></i></span>"
+
+
         ."<input $attrStr />"
       ."</div>"
       ."<div class='icons uk-margin-small-top uk-child-width-1-2 uk-child-width-1-3@s uk-child-width-1-4@m uk-child-width-1-6@l uk-grid-small' uk-grid></div>"

--- a/README.md
+++ b/README.md
@@ -5,7 +5,6 @@ https://processwire.com/talk/topic/22632-rockawesome-fontawesome-icon-picker/
 ## Usage
 
 * Install the module.
-* Copy all necessary folders to the desired location (css, media and webfonts)
 * Set paths in the Inputfield's settings page.
 * Add a RockAwesome field to any template (or change an existing TEXT field).
 

--- a/RockAwesome.module.php
+++ b/RockAwesome.module.php
@@ -45,7 +45,13 @@ class RockAwesome extends WireData implements Module, ConfigurableModule {
    * @return void
    */
   public function loadFA() {
-    $this->config->styles->add($this->fa);
+    // SEKRU: Muss als letztes geladen werden, damit es keine Konfilkte mit alter FA-Version von ProcessWire gibt
+    $this->addHookAfter('AdminTheme::getExtraMarkup', function(HookEvent $event) {
+        $parts = $event->return;
+        $parts['head'] .= '<link rel="stylesheet" href="'.$this->fa.'">';
+        $event->return = $parts;
+    });
+    // $this->config->styles->add($this->fa);
   }
 
   /**

--- a/RockAwesome.module.php
+++ b/RockAwesome.module.php
@@ -16,7 +16,7 @@ class RockAwesome extends WireData implements Module, ConfigurableModule {
       'autoload' => true,
       'singular' => true,
       'icon' => 'bolt',
-      'requires' => ['FieldtypeRockAwesome'],
+      'requires' => ['FieldtypeRockAwesome', 'InputfieldRockAwesome'],
       'installs' => [],
     ];
   }
@@ -24,9 +24,9 @@ class RockAwesome extends WireData implements Module, ConfigurableModule {
   public function init() {
     $conf = $this->modules->getConfig('InputfieldRockAwesome');
     if(!array_key_exists('stylesheet', $conf)) {
-      $url = $this->pages->get(2)->url."module/edit?name=InputfieldRockAwesome";
-      $link = "<a href='$url'>here</a>";
-      $this->warning("See setup instructions $link", Notice::allowMarkup);
+      $url = $this->pages->get(2)->url."/module/edit?name=InputfieldRockAwesome";
+      $link = "<a href='$url'>InputfieldRockAwesome</a>";
+      $this->warning("You need to add the stylesheet in $link", Notice::allowMarkup);
       return;
     }
     $fa = $this->modules->getConfig('InputfieldRockAwesome')['stylesheet'];
@@ -46,12 +46,12 @@ class RockAwesome extends WireData implements Module, ConfigurableModule {
    */
   public function loadFA() {
     // Muss als letztes geladen werden, damit es keine Konflikte mit alter FA-Version von ProcessWire gibt
-    $this->addHookAfter('AdminTheme::getExtraMarkup', function(HookEvent $event) {
-        $parts = $event->return;
-        $parts['head'] .= '<link rel="stylesheet" href="'.$this->fa.'">';
-        $event->return = $parts;
-    });
-    // $this->config->styles->add($this->fa);
+    // $this->addHookAfter('AdminTheme::getExtraMarkup', function(HookEvent $event) {
+    //     $parts = $event->return;
+    //     $parts['head'] .= '<link rel="stylesheet" href="'.$this->fa.'">';
+    //     $event->return = $parts;
+    // });
+    $this->config->styles->add($this->fa);
   }
 
   /**

--- a/RockAwesome.module.php
+++ b/RockAwesome.module.php
@@ -45,7 +45,7 @@ class RockAwesome extends WireData implements Module, ConfigurableModule {
    * @return void
    */
   public function loadFA() {
-    // SEKRU: Muss als letztes geladen werden, damit es keine Konfilkte mit alter FA-Version von ProcessWire gibt
+    // Muss als letztes geladen werden, damit es keine Konflikte mit alter FA-Version von ProcessWire gibt
     $this->addHookAfter('AdminTheme::getExtraMarkup', function(HookEvent $event) {
         $parts = $event->return;
         $parts['head'] .= '<link rel="stylesheet" href="'.$this->fa.'">';


### PR DESCRIPTION
Hi Bernhard,
hier kommt mein PR zu den im ProcessWire-Forum genannten Änderungen.

- Es wird anstatt der Metadaten-Datei die GraphQL-API von Font Awesome verwendet
- Damit ergibt sich quasi eine "Volltext"-Suche im Font Awesome-Katalog.
- Die verwendete Version kann via Select ausgewählt werden (die verfügbaren Versionen kommen auch aus der API, müssen also nicht mit jedem Versionsupdate angepasst werden).
- Man kann zwischen Pro- und Free-Lizenz wählen.
- Die Styles können eingeschränkt werden

Es gibt noch weiteres Potential, aber ich finde die Funktionen damit schon recht praktikabel!
Bitte schau mal drüber, und entscheide, ob es sich lohnt, die Änderungen zu übernehmen.
Zu bedenken ist: Zur alten Version ist das Modul inkompatibel. Die Einstellungen müssen erneut vorgenommen werden.

ciao
Sebastian

(Dies ist mein erster Pull Request in Github – ich hoffe ich mache alles richtig...)